### PR TITLE
Add prework guide and unified Colab notebook for workshop setup (EN/ES)

### DIFF
--- a/notebook/readme.md
+++ b/notebook/readme.md
@@ -1,6 +1,8 @@
 # 🚦 FiftyOne Workshop: Mobility Edition 
 ## Pre-Workshop Preparation
 
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1_eqFf8E4gC42y7oipX6BmNi_dJz-MfVv)
+
 Welcome to the **FiftyOne Mobility Workshop**!  
 To get the most out of the session, please follow the preparation steps below.
 

--- a/notebook/readme.md
+++ b/notebook/readme.md
@@ -1,0 +1,59 @@
+# 🚦 FiftyOne Workshop: Mobility Edition 
+## Pre-Workshop Preparation
+
+Welcome to the **FiftyOne Mobility Workshop**!  
+To get the most out of the session, please follow the preparation steps below.
+
+
+## Things To Do **One Day Before** the Workshop
+
+### 1. Create a Hugging Face Account (**Mandatory**)
+- Sign up at [huggingface.co](https://huggingface.co/join)
+- Go to your [Access Tokens](https://huggingface.co/settings/tokens) and create a **Read token**
+
+
+### 2. Optional but Highly Recommended Readings (📖)
+These resources will give you a head start and make the workshop smoother:
+
+- [Loading datasets from Hugging Face](https://docs.voxel51.com/integrations/huggingface.html#loading-datasets-from-the-hub)
+- [Dataset Views (Filtering, Slicing, Searching)](https://docs.voxel51.com/user_guide/using_views.html)
+- [Clustering with Embeddings](https://docs.voxel51.com/tutorials/clustering.html?highlight=embedding)
+- [MosaicML Integration (Embeddings)](https://docs.voxel51.com/integrations/mosaic.html?highlight=embedding)
+- [FiftyOne Plugins API](https://docs.voxel51.com/api/fiftyone.plugins.html?highlight=plugin#module-fiftyone.plugins)
+
+
+
+### 3. Bonus Concept to Explore: **Embeddings**
+We’ll explore this in detail during the session, but if you're curious:
+- [CLIP Paper by OpenAI](https://arxiv.org/abs/2103.00020)
+
+
+
+## ⏰ Task To Do **20 Minutes Before** the Workshop (Mandatory)
+
+> This depends on your internet speed. It could take **10–25 minutes**. Please run the following **at least 20 minutes before the workshop** in Google Colab.
+
+Just run the following cell in your Google Colab notebook:
+
+```python
+# THIS IS THE MINIMUM REQUIREMENT AFTER YOU INSTALL ALL THE DEPENDENCIES.
+import os
+import fiftyone.utils.huggingface as fouh
+from huggingface_hub import login
+
+login(token="ADD_YOUR_HF_TOKEN_HERE") 
+dataset = fouh.load_from_hub("dgural/bdd100k", persistent=True, name="bdd100k_test")
+````
+
+Make sure to **replace** `"ADD_YOUR_HF_TOKEN_HERE"` with your Hugging Face token.
+
+
+
+## 🏆 SUPER BONUS: Become an Open Source Contributor!
+
+If you **find an issue in the docs** before the workshop, you’ll earn a **premium badge of honor** 😎
+
+* Try to fix it yourself and submit a PR!
+* Can’t fix it yet? **No worries!** Tell me during the workshop and I’ll guide you through your **first open-source contribution.**
+
+Welcome to the cool club of contributors 🚀

--- a/notebook/readme_es.md
+++ b/notebook/readme_es.md
@@ -1,0 +1,57 @@
+# 🚦 Taller de FiftyOne: Edición Movilidad 
+## Preparación Antes del Taller
+
+¡Bienvenido al **Taller de FiftyOne sobre Movilidad**!  
+Para aprovechar al máximo la sesión, por favor sigue los pasos de preparación a continuación.
+
+
+## Tareas Para Hacer **Un Día Antes** del Taller
+
+### 1. Crea una Cuenta en Hugging Face (**Obligatorio**)
+- Regístrate en [huggingface.co](https://huggingface.co/join)
+- Ve a [Access Tokens](https://huggingface.co/settings/tokens) y crea un **token de lectura**
+
+
+### 2. Lecturas Opcionales pero Altamente Recomendadas (📖)
+Estos recursos te darán una ventaja y harán que el taller sea más fluido:
+
+- [Cargar datasets desde Hugging Face](https://docs.voxel51.com/integrations/huggingface.html#loading-datasets-from-the-hub)
+- [Vistas de Datasets (Filtrado, Corte, Búsqueda)](https://docs.voxel51.com/user_guide/using_views.html)
+- [Clustering con Embeddings](https://docs.voxel51.com/tutorials/clustering.html?highlight=embedding)
+- [Integración con MosaicML (Embeddings)](https://docs.voxel51.com/integrations/mosaic.html?highlight=embedding)
+- [API de Plugins de FiftyOne](https://docs.voxel51.com/api/fiftyone.plugins.html?highlight=plugin#module-fiftyone.plugins)
+
+
+
+### 3. Concepto Extra para Explorar: **Embeddings**
+Lo exploraremos a fondo durante la sesión, pero si tienes curiosidad:
+- [Artículo de CLIP por OpenAI](https://arxiv.org/abs/2103.00020)
+
+
+
+## ⏰ Tarea Para Hacer **20 Minutos Antes** del Taller (**Obligatorio**)
+
+> Esto depende de tu velocidad de internet. Puede tardar **10–25 minutos**. Por favor ejecuta lo siguiente **al menos 20 minutos antes del taller** en Google Colab.
+
+Solo ejecuta la siguiente celda en tu notebook de Google Colab:
+
+```python
+# ESTE ES EL REQUISITO MÍNIMO DESPUÉS DE INSTALAR TODAS LAS DEPENDENCIAS.
+import os
+import fiftyone.utils.huggingface as fouh
+from huggingface_hub import login
+
+login(token="AGREGA_TU_TOKEN_DE_HF_AQUÍ") 
+dataset = fouh.load_from_hub("dgural/bdd100k", persistent=True, name="bdd100k_test")
+````
+
+Asegúrate de **reemplazar** `"AGREGA_TU_TOKEN_DE_HF_AQUÍ"` con tu token de Hugging Face.
+
+## 🏆 SUPER BONUS: ¡Conviértete en Contribuidor de Código Abierto!
+
+Si **encuentras un error en la documentación** antes del taller, ganarás una **insignia premium de honor** 😎
+
+* ¡Intenta corregirlo tú mismo y haz un PR!
+* ¿No puedes arreglarlo aún? **¡No te preocupes!** Cuéntamelo durante el taller y te guiaré en tu **primera contribución a código abierto.**
+
+Bienvenido al club cool de contribuidores 🚀

--- a/notebook/readme_es.md
+++ b/notebook/readme_es.md
@@ -1,6 +1,8 @@
 # 🚦 Taller de FiftyOne: Edición Movilidad 
 ## Preparación Antes del Taller
 
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1_eqFf8E4gC42y7oipX6BmNi_dJz-MfVv)
+
 ¡Bienvenido al **Taller de FiftyOne sobre Movilidad**!  
 Para aprovechar al máximo la sesión, por favor sigue los pasos de preparación a continuación.
 


### PR DESCRIPTION
Hi Pau,

This PR includes the following updates to improve the pre-workshop experience:

Prework README added in English (README.prework.en.md) and Spanish (README.prework.es.md)
These guides outline what participants need to do one day and 20 minutes before the workshop, including Hugging Face setup, reading resources, and dataset download instructions.

Unified Google Colab notebook (prework_notebook.ipynb)
I combined the previous setup steps into one single notebook to avoid reloading the dataset multiple times, which saves bandwidth and setup time, especially given the dataset size.

Let me know what you think!

Ado 